### PR TITLE
Add CTRF Report Environment Object and Update Start and End Epoch Times

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ generate report.json file in the root directory of the project. File path is man
 pytest --ctrf report.json
 ```
 
+Environment Variables may be used to specify the required Environment Object
+fields when using the CTRF [slack-test-reporter][ctrf-slack-test-reporter-url].
+
+```bash
+CTRF_BUILD_NAME="Pytest JSON CTRF Report"
+CTRF_BUILD_NUMBER="000"
+CTRF_BUILD_URL="https://ctrf.io]"
+```
+
 ## Json exampe
 
 More info here: https://ctrf.io/docs/schema/examples
@@ -44,6 +53,11 @@ More info here: https://ctrf.io/docs/schema/examples
       "other": 0,
       "start": 1706644023,
       "stop": 1706644043
+    },
+    "environment": {
+        "buildName": "Pytest JSON CTRF Report",
+        "buildNumber": "000",
+        "buildUrl": "https://ctrf.io"
     },
     "tests": [
       {
@@ -85,3 +99,5 @@ The `pytest_runtest_logreport` hook in the controller node is used to collect th
 ### Roadmap
 - Add screenshots handling
 - Add hooks for the report extension
+
+[ctrf-slack-test-reporter-url]: https://github.com/ctrf-io/slack-test-reporter

--- a/ctrf/Report.py
+++ b/ctrf/Report.py
@@ -42,6 +42,13 @@ class Report:
             'stop': self.stop_time
         }
 
+    def _get_environment(self) -> dict:
+        return {
+            "buildName": os.getenv("CTRF_BUILD_NAME", "Pytest JSON CTRF Report"),
+            "buildNumber": os.getenv("CTRF_BUILD_NUMBER", "000"),
+            "buildUrl": os.getenv("CTRF_BUILD_URL", "https://ctrf.io"),
+        }
+
     def collect(self, report: TestReport) -> None:
         if report.nodeid not in self.test_items.keys():
             worker_id = getattr(report, 'worker_id', None)
@@ -65,6 +72,7 @@ class Report:
         return {'results': {
             "tool": self._get_tool(),
             "summary": self._get_summary(),
+            "environment": self._get_environment(),
             "tests": [test.serialize() for test in self.prepared_tests.values()]
         }
         }

--- a/ctrf/Report.py
+++ b/ctrf/Report.py
@@ -15,10 +15,10 @@ class Report:
         self.stop_time = None
 
     def start(self) -> None:
-        self.start_time = time.time()
+        self.start_time = int(time.time() * 1000)
 
     def stop(self) -> None:
-        self.stop_time = time.time()
+        self.stop_time = int(time.time() * 1000)
 
     @staticmethod
     def _get_tool() -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "pytest-json-ctrf"
-version = "0.3.2"
+version = "0.3.6"
 
 dependencies = [
     "pytest>6.0.0",


### PR DESCRIPTION
This pull request adds an Environment Object to the JSON report for use with the [Slack Test Reporter][ctrf-slack-test-reporter]. The object can be configured with the use of environment variables for use within CI pipelines, as seen in the first two attached images.

```bash
CTRF_BUILD_NAME="Pytest JSON CTRF Report"
CTRF_BUILD_NUMBER="000"
CTRF_BUILD_URL="https://ctrf.io]"
```

Finally, this pull request updates `self.start_time` and `self.stop_time` to milliseconds. This update allows the Slack Test Reporter to correctly calculate the duration of the test suite, as seen in the final image.

## Raw pytest-ctrf-json Report
<img width="528" alt="01 - pytest-json-ctrf" src="https://github.com/user-attachments/assets/01e12e62-3971-44cd-81b0-eeffa957415a" />

## Environment Object pytest-ctrf-json Report
<img width="248" alt="02 - pytest-json-ctrf" src="https://github.com/user-attachments/assets/b978cc90-5cd6-40f6-80da-95d1231edc03" />

## Epoch Millisecond pytest-ctrf-json Report
<img width="271" alt="03 - pytest-json-ctrf" src="https://github.com/user-attachments/assets/75686492-5847-4a66-90a1-2182fb224510" />

[ctrf-slack-test-reporter]: https://github.com/ctrf-io/slack-test-reporter